### PR TITLE
Feature/rbf cpfp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ldk-node"
-version = "0.6.0"
+version = "0.6.0-rc.1"
 authors = ["Elias Rohrer <dev@tnull.de>"]
 homepage = "https://lightningdevkit.org/"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ldk-node"
-version = "0.6.0+git"
+version = "0.6.0"
 authors = ["Elias Rohrer <dev@tnull.de>"]
 homepage = "https://lightningdevkit.org/"
 license = "MIT OR Apache-2.0"

--- a/Package.swift
+++ b/Package.swift
@@ -3,8 +3,8 @@
 
 import PackageDescription
 
-let tag = "v0.5.0"
-let checksum = "fd9eb84a478402af8f790519a463b6e1bf6ab3987f5951cd8375afb9d39e7a4b"
+let tag = "v0.6.0"
+let checksum = "4077bcce5f68c6bd605b4dc0a3788d381dc16fe0da81c891b45670453466d80f"
 let url = "https://github.com/lightningdevkit/ldk-node/releases/download/\(tag)/LDKNodeFFI.xcframework.zip"
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -3,8 +3,8 @@
 
 import PackageDescription
 
-let tag = "v0.6.0"
-let checksum = "4077bcce5f68c6bd605b4dc0a3788d381dc16fe0da81c891b45670453466d80f"
+let tag = "v0.6.0-rc.1"
+let checksum = "6b14ee557400b0c1c12767ed8cc9971e6c818fae5c5e0d51bb6740ab39dcb5eb"
 let url = "https://github.com/lightningdevkit/ldk-node/releases/download/\(tag)/LDKNodeFFI.xcframework.zip"
 
 let package = Package(

--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -222,6 +222,10 @@ interface OnchainPayment {
 	Txid send_to_address([ByRef]Address address, u64 amount_sats, FeeRate? fee_rate);
 	[Throws=NodeError]
 	Txid send_all_to_address([ByRef]Address address, boolean retain_reserve, FeeRate? fee_rate);
+	[Throws=NodeError]
+    Txid bump_fee_by_rbf([ByRef]Txid txid, FeeRate fee_rate);
+    [Throws=NodeError]
+    Txid accelerate_by_cpfp([ByRef]Txid txid, FeeRate? fee_rate, Address? destination_address);
 };
 
 interface FeeRate {
@@ -302,6 +306,10 @@ enum NodeError {
 	"InsufficientFunds",
 	"LiquiditySourceUnavailable",
 	"LiquidityFeeTooHigh",
+	"CannotRbfFundingTransaction",
+    "TransactionNotFound",
+    "TransactionAlreadyConfirmed",
+    "NoSpendableOutputs",
 };
 
 dictionary NodeStatus {

--- a/bindings/swift/Sources/LDKNode/LDKNode.swift
+++ b/bindings/swift/Sources/LDKNode/LDKNode.swift
@@ -511,6 +511,252 @@ fileprivate struct FfiConverterData: FfiConverterRustBuffer {
 
 
 
+public protocol Bolt11InvoiceProtocol : AnyObject {
+    
+    func amountMilliSatoshis()  -> UInt64?
+    
+    func currency()  -> Currency
+    
+    func description()  -> Bolt11InvoiceDescription
+    
+    func expiryTimeSeconds()  -> UInt64
+    
+    func fallbackAddresses()  -> [Address]
+    
+    func isExpired()  -> Bool
+    
+    func minFinalCltvExpiryDelta()  -> UInt64
+    
+    func network()  -> Network
+    
+    func paymentHash()  -> PaymentHash
+    
+    func paymentSecret()  -> PaymentSecret
+    
+    func recoverPayeePubKey()  -> PublicKey
+    
+    func routeHints()  -> [[RouteHintHop]]
+    
+    func secondsSinceEpoch()  -> UInt64
+    
+    func secondsUntilExpiry()  -> UInt64
+    
+    func signableHash()  -> [UInt8]
+    
+    func wouldExpire(atTimeSeconds: UInt64)  -> Bool
+    
+}
+
+open class Bolt11Invoice:
+    Bolt11InvoiceProtocol {
+    fileprivate let pointer: UnsafeMutableRawPointer!
+
+    /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
+    public struct NoPointer {
+        public init() {}
+    }
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+        self.pointer = pointer
+    }
+
+    /// This constructor can be used to instantiate a fake object.
+    /// - Parameter noPointer: Placeholder value so we can have a constructor separate from the default empty one that may be implemented for classes extending [FFIObject].
+    ///
+    /// - Warning:
+    ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
+    public init(noPointer: NoPointer) {
+        self.pointer = nil
+    }
+
+    public func uniffiClonePointer() -> UnsafeMutableRawPointer {
+        return try! rustCall { uniffi_ldk_node_fn_clone_bolt11invoice(self.pointer, $0) }
+    }
+    // No primary constructor declared for this class.
+
+    deinit {
+        guard let pointer = pointer else {
+            return
+        }
+
+        try! rustCall { uniffi_ldk_node_fn_free_bolt11invoice(pointer, $0) }
+    }
+
+    
+public static func fromStr(invoiceStr: String)throws  -> Bolt11Invoice {
+    return try  FfiConverterTypeBolt11Invoice.lift(try rustCallWithError(FfiConverterTypeNodeError.lift) {
+    uniffi_ldk_node_fn_constructor_bolt11invoice_from_str(
+        FfiConverterString.lower(invoiceStr),$0
+    )
+})
+}
+    
+
+    
+open func amountMilliSatoshis() -> UInt64? {
+    return try!  FfiConverterOptionUInt64.lift(try! rustCall() {
+    uniffi_ldk_node_fn_method_bolt11invoice_amount_milli_satoshis(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func currency() -> Currency {
+    return try!  FfiConverterTypeCurrency.lift(try! rustCall() {
+    uniffi_ldk_node_fn_method_bolt11invoice_currency(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func description() -> Bolt11InvoiceDescription {
+    return try!  FfiConverterTypeBolt11InvoiceDescription.lift(try! rustCall() {
+    uniffi_ldk_node_fn_method_bolt11invoice_description(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func expiryTimeSeconds() -> UInt64 {
+    return try!  FfiConverterUInt64.lift(try! rustCall() {
+    uniffi_ldk_node_fn_method_bolt11invoice_expiry_time_seconds(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func fallbackAddresses() -> [Address] {
+    return try!  FfiConverterSequenceTypeAddress.lift(try! rustCall() {
+    uniffi_ldk_node_fn_method_bolt11invoice_fallback_addresses(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isExpired() -> Bool {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_ldk_node_fn_method_bolt11invoice_is_expired(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func minFinalCltvExpiryDelta() -> UInt64 {
+    return try!  FfiConverterUInt64.lift(try! rustCall() {
+    uniffi_ldk_node_fn_method_bolt11invoice_min_final_cltv_expiry_delta(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func network() -> Network {
+    return try!  FfiConverterTypeNetwork.lift(try! rustCall() {
+    uniffi_ldk_node_fn_method_bolt11invoice_network(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func paymentHash() -> PaymentHash {
+    return try!  FfiConverterTypePaymentHash.lift(try! rustCall() {
+    uniffi_ldk_node_fn_method_bolt11invoice_payment_hash(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func paymentSecret() -> PaymentSecret {
+    return try!  FfiConverterTypePaymentSecret.lift(try! rustCall() {
+    uniffi_ldk_node_fn_method_bolt11invoice_payment_secret(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func recoverPayeePubKey() -> PublicKey {
+    return try!  FfiConverterTypePublicKey.lift(try! rustCall() {
+    uniffi_ldk_node_fn_method_bolt11invoice_recover_payee_pub_key(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func routeHints() -> [[RouteHintHop]] {
+    return try!  FfiConverterSequenceSequenceTypeRouteHintHop.lift(try! rustCall() {
+    uniffi_ldk_node_fn_method_bolt11invoice_route_hints(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func secondsSinceEpoch() -> UInt64 {
+    return try!  FfiConverterUInt64.lift(try! rustCall() {
+    uniffi_ldk_node_fn_method_bolt11invoice_seconds_since_epoch(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func secondsUntilExpiry() -> UInt64 {
+    return try!  FfiConverterUInt64.lift(try! rustCall() {
+    uniffi_ldk_node_fn_method_bolt11invoice_seconds_until_expiry(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func signableHash() -> [UInt8] {
+    return try!  FfiConverterSequenceUInt8.lift(try! rustCall() {
+    uniffi_ldk_node_fn_method_bolt11invoice_signable_hash(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func wouldExpire(atTimeSeconds: UInt64) -> Bool {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_ldk_node_fn_method_bolt11invoice_would_expire(self.uniffiClonePointer(),
+        FfiConverterUInt64.lower(atTimeSeconds),$0
+    )
+})
+}
+    
+
+}
+
+public struct FfiConverterTypeBolt11Invoice: FfiConverter {
+
+    typealias FfiType = UnsafeMutableRawPointer
+    typealias SwiftType = Bolt11Invoice
+
+    public static func lift(_ pointer: UnsafeMutableRawPointer) throws -> Bolt11Invoice {
+        return Bolt11Invoice(unsafeFromRawPointer: pointer)
+    }
+
+    public static func lower(_ value: Bolt11Invoice) -> UnsafeMutableRawPointer {
+        return value.uniffiClonePointer()
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Bolt11Invoice {
+        let v: UInt64 = try readInt(&buf)
+        // The Rust code won't compile if a pointer won't fit in a UInt64.
+        // We have to go via `UInt` because that's the thing that's the size of a pointer.
+        let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
+        if (ptr == nil) {
+            throw UniffiInternalError.unexpectedNullPointer
+        }
+        return try lift(ptr!)
+    }
+
+    public static func write(_ value: Bolt11Invoice, into buf: inout [UInt8]) {
+        // This fiddling is because `Int` is the thing that's the same size as a pointer.
+        // The Rust code won't compile if a pointer won't fit in a `UInt64`.
+        writeInt(&buf, UInt64(bitPattern: Int64(Int(bitPattern: lower(value)))))
+    }
+}
+
+
+
+
+public func FfiConverterTypeBolt11Invoice_lift(_ pointer: UnsafeMutableRawPointer) throws -> Bolt11Invoice {
+    return try FfiConverterTypeBolt11Invoice.lift(pointer)
+}
+
+public func FfiConverterTypeBolt11Invoice_lower(_ value: Bolt11Invoice) -> UnsafeMutableRawPointer {
+    return FfiConverterTypeBolt11Invoice.lower(value)
+}
+
+
+
+
 public protocol Bolt11PaymentProtocol : AnyObject {
     
     func claimForHash(paymentHash: PaymentHash, claimableAmountMsat: UInt64, preimage: PaymentPreimage) throws 
@@ -2225,6 +2471,10 @@ public func FfiConverterTypeNode_lower(_ value: Node) -> UnsafeMutableRawPointer
 
 public protocol OnchainPaymentProtocol : AnyObject {
     
+    func accelerateByCpfp(txid: Txid, feeRate: FeeRate?, destinationAddress: Address?) throws  -> Txid
+    
+    func bumpFeeByRbf(txid: Txid, feeRate: FeeRate) throws  -> Txid
+    
     func newAddress() throws  -> Address
     
     func sendAllToAddress(address: Address, retainReserve: Bool, feeRate: FeeRate?) throws  -> Txid
@@ -2273,6 +2523,25 @@ open class OnchainPayment:
 
     
 
+    
+open func accelerateByCpfp(txid: Txid, feeRate: FeeRate?, destinationAddress: Address?)throws  -> Txid {
+    return try  FfiConverterTypeTxid.lift(try rustCallWithError(FfiConverterTypeNodeError.lift) {
+    uniffi_ldk_node_fn_method_onchainpayment_accelerate_by_cpfp(self.uniffiClonePointer(),
+        FfiConverterTypeTxid.lower(txid),
+        FfiConverterOptionTypeFeeRate.lower(feeRate),
+        FfiConverterOptionTypeAddress.lower(destinationAddress),$0
+    )
+})
+}
+    
+open func bumpFeeByRbf(txid: Txid, feeRate: FeeRate)throws  -> Txid {
+    return try  FfiConverterTypeTxid.lift(try rustCallWithError(FfiConverterTypeNodeError.lift) {
+    uniffi_ldk_node_fn_method_onchainpayment_bump_fee_by_rbf(self.uniffiClonePointer(),
+        FfiConverterTypeTxid.lower(txid),
+        FfiConverterTypeFeeRate.lower(feeRate),$0
+    )
+})
+}
     
 open func newAddress()throws  -> Address {
     return try  FfiConverterTypeAddress.lift(try rustCallWithError(FfiConverterTypeNodeError.lift) {
@@ -2988,36 +3257,6 @@ public struct Bolt11PaymentInfo {
     }
 }
 
-
-
-extension Bolt11PaymentInfo: Equatable, Hashable {
-    public static func ==(lhs: Bolt11PaymentInfo, rhs: Bolt11PaymentInfo) -> Bool {
-        if lhs.state != rhs.state {
-            return false
-        }
-        if lhs.expiresAt != rhs.expiresAt {
-            return false
-        }
-        if lhs.feeTotalSat != rhs.feeTotalSat {
-            return false
-        }
-        if lhs.orderTotalSat != rhs.orderTotalSat {
-            return false
-        }
-        if lhs.invoice != rhs.invoice {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(state)
-        hasher.combine(expiresAt)
-        hasher.combine(feeTotalSat)
-        hasher.combine(orderTotalSat)
-        hasher.combine(invoice)
-    }
-}
 
 
 public struct FfiConverterTypeBolt11PaymentInfo: FfiConverterRustBuffer {
@@ -4883,6 +5122,95 @@ public func FfiConverterTypePeerDetails_lower(_ value: PeerDetails) -> RustBuffe
 }
 
 
+public struct RouteHintHop {
+    public var srcNodeId: PublicKey
+    public var shortChannelId: UInt64
+    public var cltvExpiryDelta: UInt16
+    public var htlcMinimumMsat: UInt64?
+    public var htlcMaximumMsat: UInt64?
+    public var fees: RoutingFees
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(srcNodeId: PublicKey, shortChannelId: UInt64, cltvExpiryDelta: UInt16, htlcMinimumMsat: UInt64?, htlcMaximumMsat: UInt64?, fees: RoutingFees) {
+        self.srcNodeId = srcNodeId
+        self.shortChannelId = shortChannelId
+        self.cltvExpiryDelta = cltvExpiryDelta
+        self.htlcMinimumMsat = htlcMinimumMsat
+        self.htlcMaximumMsat = htlcMaximumMsat
+        self.fees = fees
+    }
+}
+
+
+
+extension RouteHintHop: Equatable, Hashable {
+    public static func ==(lhs: RouteHintHop, rhs: RouteHintHop) -> Bool {
+        if lhs.srcNodeId != rhs.srcNodeId {
+            return false
+        }
+        if lhs.shortChannelId != rhs.shortChannelId {
+            return false
+        }
+        if lhs.cltvExpiryDelta != rhs.cltvExpiryDelta {
+            return false
+        }
+        if lhs.htlcMinimumMsat != rhs.htlcMinimumMsat {
+            return false
+        }
+        if lhs.htlcMaximumMsat != rhs.htlcMaximumMsat {
+            return false
+        }
+        if lhs.fees != rhs.fees {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(srcNodeId)
+        hasher.combine(shortChannelId)
+        hasher.combine(cltvExpiryDelta)
+        hasher.combine(htlcMinimumMsat)
+        hasher.combine(htlcMaximumMsat)
+        hasher.combine(fees)
+    }
+}
+
+
+public struct FfiConverterTypeRouteHintHop: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> RouteHintHop {
+        return
+            try RouteHintHop(
+                srcNodeId: FfiConverterTypePublicKey.read(from: &buf), 
+                shortChannelId: FfiConverterUInt64.read(from: &buf), 
+                cltvExpiryDelta: FfiConverterUInt16.read(from: &buf), 
+                htlcMinimumMsat: FfiConverterOptionUInt64.read(from: &buf), 
+                htlcMaximumMsat: FfiConverterOptionUInt64.read(from: &buf), 
+                fees: FfiConverterTypeRoutingFees.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: RouteHintHop, into buf: inout [UInt8]) {
+        FfiConverterTypePublicKey.write(value.srcNodeId, into: &buf)
+        FfiConverterUInt64.write(value.shortChannelId, into: &buf)
+        FfiConverterUInt16.write(value.cltvExpiryDelta, into: &buf)
+        FfiConverterOptionUInt64.write(value.htlcMinimumMsat, into: &buf)
+        FfiConverterOptionUInt64.write(value.htlcMaximumMsat, into: &buf)
+        FfiConverterTypeRoutingFees.write(value.fees, into: &buf)
+    }
+}
+
+
+public func FfiConverterTypeRouteHintHop_lift(_ buf: RustBuffer) throws -> RouteHintHop {
+    return try FfiConverterTypeRouteHintHop.lift(buf)
+}
+
+public func FfiConverterTypeRouteHintHop_lower(_ value: RouteHintHop) -> RustBuffer {
+    return FfiConverterTypeRouteHintHop.lower(value)
+}
+
+
 public struct RoutingFees {
     public var baseMsat: UInt32
     public var proportionalMillionths: UInt32
@@ -5503,6 +5831,82 @@ public func FfiConverterTypeConfirmationStatus_lower(_ value: ConfirmationStatus
 
 
 extension ConfirmationStatus: Equatable, Hashable {}
+
+
+
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+
+public enum Currency {
+    
+    case bitcoin
+    case bitcoinTestnet
+    case regtest
+    case simnet
+    case signet
+}
+
+
+public struct FfiConverterTypeCurrency: FfiConverterRustBuffer {
+    typealias SwiftType = Currency
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Currency {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+        
+        case 1: return .bitcoin
+        
+        case 2: return .bitcoinTestnet
+        
+        case 3: return .regtest
+        
+        case 4: return .simnet
+        
+        case 5: return .signet
+        
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: Currency, into buf: inout [UInt8]) {
+        switch value {
+        
+        
+        case .bitcoin:
+            writeInt(&buf, Int32(1))
+        
+        
+        case .bitcoinTestnet:
+            writeInt(&buf, Int32(2))
+        
+        
+        case .regtest:
+            writeInt(&buf, Int32(3))
+        
+        
+        case .simnet:
+            writeInt(&buf, Int32(4))
+        
+        
+        case .signet:
+            writeInt(&buf, Int32(5))
+        
+        }
+    }
+}
+
+
+public func FfiConverterTypeCurrency_lift(_ buf: RustBuffer) throws -> Currency {
+    return try FfiConverterTypeCurrency.lift(buf)
+}
+
+public func FfiConverterTypeCurrency_lower(_ value: Currency) -> RustBuffer {
+    return FfiConverterTypeCurrency.lower(value)
+}
+
+
+
+extension Currency: Equatable, Hashable {}
 
 
 
@@ -6165,6 +6569,14 @@ public enum NodeError {
     
     case LiquidityFeeTooHigh(message: String)
     
+    case CannotRbfFundingTransaction(message: String)
+    
+    case TransactionNotFound(message: String)
+    
+    case TransactionAlreadyConfirmed(message: String)
+    
+    case NoSpendableOutputs(message: String)
+    
 }
 
 
@@ -6386,6 +6798,22 @@ public struct FfiConverterTypeNodeError: FfiConverterRustBuffer {
             message: try FfiConverterString.read(from: &buf)
         )
         
+        case 53: return .CannotRbfFundingTransaction(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
+        case 54: return .TransactionNotFound(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
+        case 55: return .TransactionAlreadyConfirmed(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
+        case 56: return .NoSpendableOutputs(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
 
         default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -6501,6 +6929,14 @@ public struct FfiConverterTypeNodeError: FfiConverterRustBuffer {
             writeInt(&buf, Int32(51))
         case .LiquidityFeeTooHigh(_ /* message is ignored*/):
             writeInt(&buf, Int32(52))
+        case .CannotRbfFundingTransaction(_ /* message is ignored*/):
+            writeInt(&buf, Int32(53))
+        case .TransactionNotFound(_ /* message is ignored*/):
+            writeInt(&buf, Int32(54))
+        case .TransactionAlreadyConfirmed(_ /* message is ignored*/):
+            writeInt(&buf, Int32(55))
+        case .NoSpendableOutputs(_ /* message is ignored*/):
+            writeInt(&buf, Int32(56))
 
         
         }
@@ -8072,6 +8508,28 @@ fileprivate struct FfiConverterSequenceTypePeerDetails: FfiConverterRustBuffer {
     }
 }
 
+fileprivate struct FfiConverterSequenceTypeRouteHintHop: FfiConverterRustBuffer {
+    typealias SwiftType = [RouteHintHop]
+
+    public static func write(_ value: [RouteHintHop], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterTypeRouteHintHop.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [RouteHintHop] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [RouteHintHop]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterTypeRouteHintHop.read(from: &buf))
+        }
+        return seq
+    }
+}
+
 fileprivate struct FfiConverterSequenceTypeLightningBalance: FfiConverterRustBuffer {
     typealias SwiftType = [LightningBalance]
 
@@ -8111,6 +8569,50 @@ fileprivate struct FfiConverterSequenceTypePendingSweepBalance: FfiConverterRust
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
             seq.append(try FfiConverterTypePendingSweepBalance.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+fileprivate struct FfiConverterSequenceSequenceTypeRouteHintHop: FfiConverterRustBuffer {
+    typealias SwiftType = [[RouteHintHop]]
+
+    public static func write(_ value: [[RouteHintHop]], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterSequenceTypeRouteHintHop.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [[RouteHintHop]] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [[RouteHintHop]]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterSequenceTypeRouteHintHop.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+fileprivate struct FfiConverterSequenceTypeAddress: FfiConverterRustBuffer {
+    typealias SwiftType = [Address]
+
+    public static func write(_ value: [Address], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterTypeAddress.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [Address] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [Address]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterTypeAddress.read(from: &buf))
         }
         return seq
     }
@@ -8270,40 +8772,6 @@ public func FfiConverterTypeBlockHash_lift(_ value: RustBuffer) throws -> BlockH
 
 public func FfiConverterTypeBlockHash_lower(_ value: BlockHash) -> RustBuffer {
     return FfiConverterTypeBlockHash.lower(value)
-}
-
-
-
-/**
- * Typealias from the type name used in the UDL file to the builtin type.  This
- * is needed because the UDL type name is used in function/method signatures.
- */
-public typealias Bolt11Invoice = String
-public struct FfiConverterTypeBolt11Invoice: FfiConverter {
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Bolt11Invoice {
-        return try FfiConverterString.read(from: &buf)
-    }
-
-    public static func write(_ value: Bolt11Invoice, into buf: inout [UInt8]) {
-        return FfiConverterString.write(value, into: &buf)
-    }
-
-    public static func lift(_ value: RustBuffer) throws -> Bolt11Invoice {
-        return try FfiConverterString.lift(value)
-    }
-
-    public static func lower(_ value: Bolt11Invoice) -> RustBuffer {
-        return FfiConverterString.lower(value)
-    }
-}
-
-
-public func FfiConverterTypeBolt11Invoice_lift(_ value: RustBuffer) throws -> Bolt11Invoice {
-    return try FfiConverterTypeBolt11Invoice.lift(value)
-}
-
-public func FfiConverterTypeBolt11Invoice_lower(_ value: Bolt11Invoice) -> RustBuffer {
-    return FfiConverterTypeBolt11Invoice.lower(value)
 }
 
 
@@ -9032,40 +9500,88 @@ private var initializationResult: InitializationResult {
     if (uniffi_ldk_node_checksum_func_generate_entropy_mnemonic() != 59926) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_ldk_node_checksum_method_bolt11invoice_amount_milli_satoshis() != 50823) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ldk_node_checksum_method_bolt11invoice_currency() != 32179) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ldk_node_checksum_method_bolt11invoice_description() != 9887) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ldk_node_checksum_method_bolt11invoice_expiry_time_seconds() != 23625) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ldk_node_checksum_method_bolt11invoice_fallback_addresses() != 55276) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ldk_node_checksum_method_bolt11invoice_is_expired() != 15932) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ldk_node_checksum_method_bolt11invoice_min_final_cltv_expiry_delta() != 8855) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ldk_node_checksum_method_bolt11invoice_network() != 10420) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ldk_node_checksum_method_bolt11invoice_payment_hash() != 42571) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ldk_node_checksum_method_bolt11invoice_payment_secret() != 26081) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ldk_node_checksum_method_bolt11invoice_recover_payee_pub_key() != 18874) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ldk_node_checksum_method_bolt11invoice_route_hints() != 63051) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ldk_node_checksum_method_bolt11invoice_seconds_since_epoch() != 53979) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ldk_node_checksum_method_bolt11invoice_seconds_until_expiry() != 64193) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ldk_node_checksum_method_bolt11invoice_signable_hash() != 30910) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ldk_node_checksum_method_bolt11invoice_would_expire() != 30331) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_ldk_node_checksum_method_bolt11payment_claim_for_hash() != 52848) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ldk_node_checksum_method_bolt11payment_fail_for_hash() != 24516) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_ldk_node_checksum_method_bolt11payment_receive() != 47624) {
+    if (uniffi_ldk_node_checksum_method_bolt11payment_receive() != 6073) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_ldk_node_checksum_method_bolt11payment_receive_for_hash() != 36395) {
+    if (uniffi_ldk_node_checksum_method_bolt11payment_receive_for_hash() != 27050) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_ldk_node_checksum_method_bolt11payment_receive_variable_amount() != 38916) {
+    if (uniffi_ldk_node_checksum_method_bolt11payment_receive_variable_amount() != 4893) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_ldk_node_checksum_method_bolt11payment_receive_variable_amount_for_hash() != 9075) {
+    if (uniffi_ldk_node_checksum_method_bolt11payment_receive_variable_amount_for_hash() != 1402) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_ldk_node_checksum_method_bolt11payment_receive_variable_amount_via_jit_channel() != 58805) {
+    if (uniffi_ldk_node_checksum_method_bolt11payment_receive_variable_amount_via_jit_channel() != 24506) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_ldk_node_checksum_method_bolt11payment_receive_via_jit_channel() != 30211) {
+    if (uniffi_ldk_node_checksum_method_bolt11payment_receive_via_jit_channel() != 16532) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_ldk_node_checksum_method_bolt11payment_send() != 39133) {
+    if (uniffi_ldk_node_checksum_method_bolt11payment_send() != 63952) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_ldk_node_checksum_method_bolt11payment_send_probes() != 39625) {
+    if (uniffi_ldk_node_checksum_method_bolt11payment_send_probes() != 969) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_ldk_node_checksum_method_bolt11payment_send_probes_using_amount() != 25010) {
+    if (uniffi_ldk_node_checksum_method_bolt11payment_send_probes_using_amount() != 50136) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_ldk_node_checksum_method_bolt11payment_send_using_amount() != 19557) {
+    if (uniffi_ldk_node_checksum_method_bolt11payment_send_using_amount() != 36530) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ldk_node_checksum_method_bolt12payment_initiate_refund() != 38039) {
@@ -9293,6 +9809,12 @@ private var initializationResult: InitializationResult {
     if (uniffi_ldk_node_checksum_method_node_wait_next_event() != 55101) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_ldk_node_checksum_method_onchainpayment_accelerate_by_cpfp() != 31954) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ldk_node_checksum_method_onchainpayment_bump_fee_by_rbf() != 53877) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_ldk_node_checksum_method_onchainpayment_new_address() != 37251) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -9318,6 +9840,9 @@ private var initializationResult: InitializationResult {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ldk_node_checksum_method_vssheaderprovider_get_headers() != 7788) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ldk_node_checksum_constructor_bolt11invoice_from_str() != 349) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ldk_node_checksum_constructor_builder_from_config() != 994) {

--- a/src/error.rs
+++ b/src/error.rs
@@ -120,6 +120,14 @@ pub enum Error {
 	LiquiditySourceUnavailable,
 	/// The given operation failed due to the LSP's required opening fee being too high.
 	LiquidityFeeTooHigh,
+	/// Cannot RBF a channel funding transaction.
+	CannotRbfFundingTransaction,
+	/// The transaction was not found in the wallet.
+	TransactionNotFound,
+	/// The transaction is already confirmed and cannot be modified.
+	TransactionAlreadyConfirmed,
+	/// The transaction has no spendable outputs.
+	NoSpendableOutputs
 }
 
 impl fmt::Display for Error {
@@ -193,6 +201,10 @@ impl fmt::Display for Error {
 			Self::LiquidityFeeTooHigh => {
 				write!(f, "The given operation failed due to the LSP's required opening fee being too high.")
 			},
+			Self::CannotRbfFundingTransaction => write!(f, "Cannot RBF a channel funding transaction."),
+			Self::TransactionNotFound => write!(f, "The transaction was not found in the wallet."),
+			Self::TransactionAlreadyConfirmed => write!(f, "The transaction is already confirmed and cannot be modified."),
+			Self::NoSpendableOutputs => write!(f, "The transaction has no spendable outputs.")
 		}
 	}
 }


### PR DESCRIPTION
Add Replace-By-Fee (RBF) and Child-Pays-For-Parent (CPFP) functionality
to allow users to bump fees on stuck transactions.

- Add `bump_fee_by_rbf` to replace transactions with higher fee versions
- Add `accelerate_by_cpfp` to create child transactions that pay for parent
- Add `calculate_cpfp_fee_rate` helper for automatic fee calculation
- Add new error variants for transaction fee bumping operations
- Expose methods through `OnchainPayment` API
- Add UniFFI bindings for RBF/CPFP functionality

RBF allows replacing an existing unconfirmed transaction with a new version
that pays a higher fee. CPFP allows accelerating a transaction by spending
one of its outputs with a high-fee child transaction.

Release Candidate has been made available for testing [here](https://github.com/synonymdev/ldk-node/releases/tag/v0.6.0-rc.1).