### PR TITLE
chore: bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ldk-node"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 authors = ["Elias Rohrer <dev@tnull.de>"]
 homepage = "https://lightningdevkit.org/"
 license = "MIT OR Apache-2.0"

--- a/Package.swift
+++ b/Package.swift
@@ -3,8 +3,8 @@
 
 import PackageDescription
 
-let tag = "v0.6.0-rc.1"
-let checksum = "6b14ee557400b0c1c12767ed8cc9971e6c818fae5c5e0d51bb6740ab39dcb5eb"
+let tag = "v0.6.0-rc.2"
+let checksum = "5fbb59a02cb596707b25d56d255ba0706873852962d1108826b57778347c859e"
 let url = "https://github.com/synonymdev/ldk-node/releases/download/\(tag)/LDKNodeFFI.xcframework.zip"
 
 let package = Package(

--- a/bindings/kotlin/ldk-node-android/gradle.properties
+++ b/bindings/kotlin/ldk-node-android/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official
-libraryVersion=v0.6.0-rc.1
+libraryVersion=v0.6.0-rc.2


### PR DESCRIPTION
This PR:
- Bumps version to `0.6.0-rc.2`.
- Updates `gradle.properties` and `Package.swift` accordingly.