### PR TITLE
feat(probe): expose probe route fees in events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ swift.swiftdoc
 .claude
 *.local.*
 .ai
+.vscode

--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -539,8 +539,8 @@ interface Event {
 	PaymentClaimable(PaymentId payment_id, PaymentHash payment_hash, u64 claimable_amount_msat, u32? claim_deadline, sequence<CustomTlvRecord> custom_records);
 	PaymentForwarded(ChannelId prev_channel_id, ChannelId next_channel_id, UserChannelId?
 	prev_user_channel_id, UserChannelId? next_user_channel_id, PublicKey? prev_node_id, PublicKey? next_node_id, u64? total_fee_earned_msat, u64? skimmed_fee_msat, boolean claim_from_onchain_tx, u64? outbound_amount_forwarded_msat);
-	ProbeSuccessful(PaymentId payment_id, PaymentHash payment_hash);
-	ProbeFailed(PaymentId payment_id, PaymentHash payment_hash, u64? short_channel_id);
+	ProbeSuccessful(PaymentId payment_id, PaymentHash payment_hash, u64? route_fee_msat);
+	ProbeFailed(PaymentId payment_id, PaymentHash payment_hash, u64? short_channel_id, u64? route_fee_msat);
 	ChannelPending(ChannelId channel_id, UserChannelId user_channel_id, ChannelId former_temporary_channel_id, PublicKey counterparty_node_id, OutPoint funding_txo);
 	ChannelReady(ChannelId channel_id, UserChannelId user_channel_id, PublicKey? counterparty_node_id, OutPoint? funding_txo);
 	ChannelClosed(ChannelId channel_id, UserChannelId user_channel_id, PublicKey? counterparty_node_id, ClosureReason? reason);

--- a/src/event.rs
+++ b/src/event.rs
@@ -424,6 +424,8 @@ pub enum Event {
 		payment_id: PaymentId,
 		/// The hash of the probe payment.
 		payment_hash: PaymentHash,
+		/// The total routing fee paid by the probe path, in thousandths of a satoshi.
+		route_fee_msat: Option<u64>,
 	},
 	/// A sent payment probe has failed.
 	ProbeFailed {
@@ -433,6 +435,8 @@ pub enum Event {
 		payment_hash: PaymentHash,
 		/// The channel responsible for the failed probe, if known.
 		short_channel_id: Option<u64>,
+		/// The total routing fee for the failed probe path, in thousandths of a satoshi.
+		route_fee_msat: Option<u64>,
 	},
 	/// A channel has been created and is pending confirmation on-chain.
 	ChannelPending {
@@ -964,11 +968,13 @@ impl_writeable_tlv_based_enum!(Event,
 	(18, ProbeSuccessful) => {
 		(0, payment_hash, required),
 		(2, payment_id, required),
+		(4, route_fee_msat, option),
 	},
 	(19, ProbeFailed) => {
 		(0, payment_hash, required),
 		(1, short_channel_id, option),
 		(3, payment_id, required),
+		(5, route_fee_msat, option),
 	}
 );
 
@@ -1804,8 +1810,9 @@ where
 
 			LdkEvent::PaymentPathSuccessful { .. } => {},
 			LdkEvent::PaymentPathFailed { .. } => {},
-			LdkEvent::ProbeSuccessful { payment_id, payment_hash, .. } => {
-				let event = Event::ProbeSuccessful { payment_id, payment_hash };
+			LdkEvent::ProbeSuccessful { payment_id, payment_hash, path, .. } => {
+				let route_fee_msat = Some(path.fee_msat());
+				let event = Event::ProbeSuccessful { payment_id, payment_hash, route_fee_msat };
 				match self.event_queue.add_event(event).await {
 					Ok(_) => {},
 					Err(e) => {
@@ -1814,8 +1821,14 @@ where
 					},
 				}
 			},
-			LdkEvent::ProbeFailed { payment_id, payment_hash, short_channel_id, .. } => {
-				let event = Event::ProbeFailed { payment_id, payment_hash, short_channel_id };
+			LdkEvent::ProbeFailed { payment_id, payment_hash, short_channel_id, path, .. } => {
+				let route_fee_msat = Some(path.fee_msat());
+				let event = Event::ProbeFailed {
+					payment_id,
+					payment_hash,
+					short_channel_id,
+					route_fee_msat,
+				};
 				match self.event_queue.add_event(event).await {
 					Ok(_) => {},
 					Err(e) => {
@@ -2606,16 +2619,19 @@ mod tests {
 			Event::ProbeSuccessful {
 				payment_id: PaymentId([1u8; 32]),
 				payment_hash: PaymentHash([2u8; 32]),
+				route_fee_msat: Some(1_234),
 			},
 			Event::ProbeFailed {
 				payment_id: PaymentId([3u8; 32]),
 				payment_hash: PaymentHash([4u8; 32]),
 				short_channel_id: Some(42),
+				route_fee_msat: Some(5_678),
 			},
 			Event::ProbeFailed {
 				payment_id: PaymentId([5u8; 32]),
 				payment_hash: PaymentHash([6u8; 32]),
 				short_channel_id: None,
+				route_fee_msat: None,
 			},
 		];
 


### PR DESCRIPTION
## Summary

Expose the actual route fee for Lightning probe results.

This adds `route_fee_msat` to `ProbeSuccessful` and `ProbeFailed` events and populates it from LDK’s `Path::fee_msat()`, which reports routing fees without including the delivered amount from the final hop.

## Details

- Adds `route_fee_msat: Option<u64>` to probe event types
- Persists the new field with fresh TLV indexes for backwards-compatible event decoding
- Updates the UniFFI UDL event definitions
- Extends probe event persistence roundtrip coverage

Bindings were not regenerated in this PR.

## Verification

- `cargo fmt`
- `cargo test --lib probe_events_persistence_roundtrip`
- Verified by implementing in bitkit-ios