### PR TITLE
chore: release 0.7.0-rc.53

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["bindings/uniffi-bindgen"]
 
 [package]
 name = "ldk-node"
-version = "0.7.0-rc.52"
+version = "0.7.0-rc.53"
 authors = ["Elias Rohrer <dev@tnull.de>"]
 homepage = "https://lightningdevkit.org/"
 license = "MIT OR Apache-2.0"

--- a/Package.swift
+++ b/Package.swift
@@ -3,8 +3,8 @@
 
 import PackageDescription
 
-let tag = "v0.7.0-rc.52"
-let checksum = "bfa1de808ed8b457f6c5aaf911b96806d995fd2a40c04b2b2e27aa75ab206098"
+let tag = "v0.7.0-rc.53"
+let checksum = "fc960df1f626c25d1ed9b171d52514cdbf97341e53b12dffead54483cdba9533"
 let url = "https://github.com/synonymdev/ldk-node/releases/download/\(tag)/LDKNodeFFI.xcframework.zip"
 
 let package = Package(

--- a/bindings/kotlin/ldk-node-android/gradle.properties
+++ b/bindings/kotlin/ldk-node-android/gradle.properties
@@ -3,4 +3,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official
 group=com.synonym
-version=0.7.0-rc.52
+version=0.7.0-rc.53

--- a/bindings/kotlin/ldk-node-jvm/gradle.properties
+++ b/bindings/kotlin/ldk-node-jvm/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.jvmargs=-Xmx1536m
 kotlin.code.style=official
 group=com.synonym
-version=0.7.0-rc.52
+version=0.7.0-rc.53


### PR DESCRIPTION
## What's Changed

- Fixed the SwiftPM `LDKNodeFFI` binary target checksum for the iOS artifact.
- Re-published the iOS XCFramework artifact under `v0.7.0-rc.53`.