### PR TITLE
ci: fix JVM package publishing

### DIFF
--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to publish (e.g., v0.1.0)"
+        description: "Version/tag to publish (e.g., v0.7.0-rc.54 or 0.7.0-rc.54)"
         required: true
 
 jobs:
@@ -17,7 +17,21 @@ jobs:
       packages: write
 
     steps:
+    - name: Normalize release version
+      id: version
+      shell: bash
+      run: |
+        VERSION="${{ github.event.inputs.version || github.event.release.tag_name || github.ref_name }}"
+        TAG="$VERSION"
+        if [[ "$TAG" != v* ]]; then
+          TAG="v$TAG"
+        fi
+        echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+        echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ steps.version.outputs.tag }}
     - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
@@ -29,16 +43,6 @@ jobs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
 
-    - name: Extract version from input or tag
-      id: version
-      shell: bash
-      run: |
-        VERSION="${{ inputs.version }}"
-        if [[ -z "$VERSION" ]]; then
-          VERSION="$GITHUB_REF_NAME"
-        fi
-        echo "version=${VERSION#v}" >> $GITHUB_OUTPUT
-
     - name: Build with Gradle
       working-directory: bindings/kotlin/ldk-node-jvm
       run: ./gradlew build -x test -Pversion=${{ steps.version.outputs.version }}
@@ -47,6 +51,6 @@ jobs:
       working-directory: bindings/kotlin/ldk-node-jvm
       env:
         GITHUB_ACTOR: ${{ github.actor }}
-        GITHUB_TOKEN: ${{ secrets.ORG_PACKAGES_TOKEN }}
+        GITHUB_TOKEN: ${{ github.token }}
         GITHUB_REPO: ${{ github.repository }}
       run: ./gradlew publish -Pversion=${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Summary

- publish the JVM package with the workflow-scoped GitHub token, which already has `packages: write`
- normalize release and manual-dispatch versions to a tag and explicitly check out that tag

## Context

The JVM package build succeeds, but publication has failed with `401 Unauthorized` for every release from rc47 through rc54 because the workflow still uses the stale `ORG_PACKAGES_TOKEN`. This matches the failure fixed in `synonymdev/bitkit-core#93` and aligns the JVM workflow with the existing Android publish workflow.

## Verification

- `cargo fmt --check`
- YAML syntax parsed successfully
- version normalization verified for `v0.7.0-rc.54` and `0.7.0-rc.54`
- `git diff --check`

## Recovery

After merge, manually dispatch `JVM Publish` from `main` with version `v0.7.0-rc.54`. Re-running the original release job would continue using the workflow stored at the rc54 tag.
