### PR TITLE
ci: add mobile bindgen validation workflows

### DIFF
--- a/.github/workflows/android-bindgen.yml
+++ b/.github/workflows/android-bindgen.yml
@@ -1,0 +1,80 @@
+name: Android Bindgen
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or SHA to build"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  android-bindgen:
+    name: Android Bindgen
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: temurin
+
+      - name: Install native build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config protobuf-compiler zip unzip
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Set up Android NDK
+        id: setup-ndk
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r28c
+          add-to-path: true
+
+      - name: Export Android NDK root
+        run: echo "ANDROID_NDK_ROOT=${{ steps.setup-ndk.outputs.ndk-path }}" >> "$GITHUB_ENV"
+
+      - name: Generate Android bindings and artifacts
+        run: ./scripts/uniffi_bindgen_generate_kotlin_android.sh
+
+      - name: Verify Android outputs
+        run: |
+          test -f bindings/kotlin/ldk-node-android/lib/src/main/kotlin/org/lightningdevkit/ldknode/ldk_node.android.kt
+          test -f bindings/kotlin/ldk-node-android/lib/src/main/kotlin/org/lightningdevkit/ldknode/ldk_node.common.kt
+          test -f bindings/kotlin/ldk-node-android/lib/src/main/jniLibs/armeabi-v7a/libldk_node.so
+          test -f bindings/kotlin/ldk-node-android/lib/src/main/jniLibs/arm64-v8a/libldk_node.so
+          test -f bindings/kotlin/ldk-node-android/lib/src/main/jniLibs/x86_64/libldk_node.so
+          test -f bindings/kotlin/ldk-node-android/native-debug-symbols.zip
+          test -f bindings/kotlin/ldk-node-android/lib/build/outputs/aar/lib-release.aar
+          zip -T bindings/kotlin/ldk-node-android/native-debug-symbols.zip
+
+      - name: Upload Android generated outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: ldk-node-android-bindgen
+          path: |
+            bindings/kotlin/ldk-node-android/lib/src/main/kotlin/org/lightningdevkit/ldknode/ldk_node.android.kt
+            bindings/kotlin/ldk-node-android/lib/src/main/kotlin/org/lightningdevkit/ldknode/ldk_node.common.kt
+            bindings/kotlin/ldk-node-android/lib/src/main/jniLibs/**/libldk_node.so
+            bindings/kotlin/ldk-node-android/native-debug-symbols.zip
+            bindings/kotlin/ldk-node-android/lib/build/outputs/aar/*.aar
+          if-no-files-found: error

--- a/.github/workflows/bindgen-validation.yml
+++ b/.github/workflows/bindgen-validation.yml
@@ -1,0 +1,68 @@
+name: Bindgen Validation
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validation:
+    name: Script and manifest checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: temurin
+
+      - name: Check shell script syntax
+        run: |
+          bash -n bindgen.sh
+          bash -n scripts/uniffi_bindgen_generate.sh
+          bash -n scripts/uniffi_bindgen_generate_swift.sh
+          bash -n scripts/uniffi_bindgen_generate_kotlin.sh
+          bash -n scripts/uniffi_bindgen_generate_kotlin_android.sh
+          bash -n scripts/uniffi_bindgen_generate_python.sh
+          bash -n scripts/swift_create_xcframework_archive.sh
+          bash -n scripts/python_create_package.sh
+          bash -n scripts/generate_checksum_files.sh
+          bash -n scripts/format_kotlin.sh
+          bash -n scripts/normalize_generated_whitespace.sh
+
+      - name: Check Cargo metadata
+        run: cargo metadata --locked --format-version 1 --no-deps
+
+      - name: Check root SwiftPM manifest
+        env:
+          CLANG_MODULE_CACHE_PATH: .build/module-cache
+        run: swift package dump-package
+
+      - name: Check local SwiftPM manifest
+        working-directory: bindings/swift
+        env:
+          CLANG_MODULE_CACHE_PATH: .build/module-cache
+        run: swift package dump-package
+
+      - name: Check Android Gradle manifest
+        working-directory: bindings/kotlin/ldk-node-android
+        run: ./gradlew projects --no-daemon
+
+      - name: Check JVM Gradle manifest
+        working-directory: bindings/kotlin/ldk-node-jvm
+        run: ./gradlew projects --no-daemon
+
+      - name: Check Python package metadata
+        run: python3 -c 'from pathlib import Path; data = Path("bindings/python/pyproject.toml").read_text(); assert "[project]" in data and "name = \"ldk_node\"" in data'

--- a/.github/workflows/ios-bindgen.yml
+++ b/.github/workflows/ios-bindgen.yml
@@ -1,0 +1,61 @@
+name: iOS Bindgen
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or SHA to build"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  ios-bindgen:
+    name: iOS Bindgen
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Validate root SwiftPM manifest
+        env:
+          CLANG_MODULE_CACHE_PATH: .build/module-cache
+        run: swift package dump-package
+
+      - name: Generate Swift bindings and XCFramework
+        run: |
+          ./scripts/uniffi_bindgen_generate_swift.sh
+          ./scripts/swift_create_xcframework_archive.sh
+
+      - name: Verify iOS outputs
+        run: |
+          test -f bindings/swift/Sources/LDKNode/LDKNode.swift
+          test -d bindings/swift/LDKNodeFFI.xcframework
+          test -f bindings/swift/LDKNodeFFI.xcframework/Info.plist
+          test -f bindings/swift/LDKNodeFFI.xcframework/ios-arm64/LDKNodeFFI.framework/Headers/LDKNodeFFI.h
+          test -f bindings/swift/LDKNodeFFI.xcframework/ios-arm64_x86_64-simulator/LDKNodeFFI.framework/Headers/LDKNodeFFI.h
+          test -f bindings/swift/LDKNodeFFI.xcframework/macos-arm64_x86_64/LDKNodeFFI.framework/Headers/LDKNodeFFI.h
+          test -f bindings/swift/LDKNodeFFI.xcframework.zip
+          swift package compute-checksum bindings/swift/LDKNodeFFI.xcframework.zip
+
+      - name: Upload iOS generated outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: ldk-node-ios-bindgen
+          path: |
+            bindings/swift/Sources/LDKNode/LDKNode.swift
+            bindings/swift/LDKNodeFFI.xcframework
+            bindings/swift/LDKNodeFFI.xcframework.zip
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
- Add script/manifest validation workflow
- Add iOS bindgen workflow that generates Swift/XCFramework outputs and uploads them for review
- Add Android bindgen workflow that generates Kotlin/JNI/debug-symbol/AAR outputs and uploads them for review

## Notes
This branch does not remove tracked generated artifacts and does not publish release artifacts.

iOS release automation is intentionally deferred; see https://github.com/synonymdev/vss-rust-client-ffi/pull/22 for prior decision context.
